### PR TITLE
Added bus interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # commissaire-http
-Prototype Commissaire http server
+Commissaire HTTP server

--- a/example/http_server.py
+++ b/example/http_server.py
@@ -24,17 +24,13 @@ from commissaire_http.router import Router
 from commissaire_http import CommissaireHttpServer
 
 # NOTE: Only added for this example
-logger = logging.getLogger('Dispatcher')
-logger.setLevel(logging.DEBUG)
-handler = logging.StreamHandler()
-handler.setFormatter(logging.Formatter('%(name)s(%(levelname)s): %(message)s'))
-logger.handlers.append(handler)
-
-r = logging.getLogger('Router')
-r.setLevel(logging.DEBUG)
-handler = logging.StreamHandler()
-handler.setFormatter(logging.Formatter('%(name)s(%(levelname)s): %(message)s'))
-r.handlers.append(handler)
+for name in ('Dispatcher', 'Router', 'Bus', 'CommissaireHttpServer'):
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.DEBUG)
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter(
+        '%(name)s(%(levelname)s): %(message)s'))
+    logger.handlers.append(handler)
 # --
 
 

--- a/example/http_server.py
+++ b/example/http_server.py
@@ -53,6 +53,10 @@ dispatcher = Dispatcher(mapper, handler_packages=['commissaire_http.handlers'])
 
 try:
     server = CommissaireHttpServer('127.0.0.1', 8000, dispatcher)
+    server.setup_bus(
+        'commissaire',
+        'redis://127.0.0.1:6379/',
+        [{'name': 'simple', 'routing_key': 'simple.*'}])
     server.serve_forever()
 except KeyboardInterrupt:
     pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 ignore=E402
 exclude=test/*
-max-complexity=10
+max-complexity=12
 
 [nosetests]
 verbosity=2

--- a/src/commissaire_http/__init__.py
+++ b/src/commissaire_http/__init__.py
@@ -19,8 +19,10 @@ Prototype http server.
 
 import logging
 
-from wsgiref.simple_server import WSGIServer, make_server
+from wsgiref.simple_server import WSGIServer, WSGIRequestHandler, make_server
 from socketserver import ThreadingMixIn
+
+from commissaire_http.bus import Bus
 
 
 class ThreadedWSGIServer(ThreadingMixIn, WSGIServer):
@@ -30,25 +32,39 @@ class ThreadedWSGIServer(ThreadingMixIn, WSGIServer):
     pass
 
 
+class CommisaireRequestHandler(WSGIRequestHandler):
+    """
+    Commissaire version of the WSGIRequestHandler.
+    """
+    #: The version of the server
+    server_version = 'Commissaire/0.0.2'
+
+
 class CommissaireHttpServer:
     """
     Http Server for Commissaire.
     """
 
+    #: Class level logger
     logger = logging.getLogger('CommissaireHttpServer')
 
     def __init__(self, bind_host, bind_port, dispatcher, tls_pem_file=None):
         """
         Initializes a new CommissaireHttpServer instance.
         """
+        # To use the bus call setup_bus()
+        self.bus = None
         self._bind_host = bind_host
         self._bind_port = bind_port
         self._tls_pem_file = tls_pem_file
+        self.dispatcher = dispatcher
         self._httpd = make_server(
             self._bind_host,
             self._bind_port,
-            dispatcher.dispatch,
-            server_class=ThreadedWSGIServer)
+            self.dispatcher.dispatch,
+            server_class=ThreadedWSGIServer,
+            handler_class=CommisaireRequestHandler)
+
         # If we are given a PEM file then wrap the socket
         if tls_pem_file:
             import ssl
@@ -61,6 +77,23 @@ class CommissaireHttpServer:
 
         self.logger.debug('Created httpd server: {}:{}'.format(
             self._bind_host, self._bind_port))
+
+    def setup_bus(self, exchange_name, connection_url, qkwargs):
+        """
+        Sets up variables needed for the bus connection.
+
+        :param exchange_name: Name of the topic exchange.
+        :type exchange_name: str
+        :param connection_url: Kombu connection url.
+        :type connection_url: str
+        :param qkwargs: One or more dicts keyword arguments for queue creation
+        :type qkwargs: list
+        """
+        self.logger.debug('Setting up bus connection.')
+        self.bus = Bus(exchange_name, connection_url, qkwargs)
+        self.bus.connect()
+        self.dispatcher._bus = self.bus
+        self.logger.info('Bus connection ready.')
 
     def serve_forever(self):
         """

--- a/src/commissaire_http/__init__.py
+++ b/src/commissaire_http/__init__.py
@@ -32,7 +32,7 @@ class ThreadedWSGIServer(ThreadingMixIn, WSGIServer):
     pass
 
 
-class CommisaireRequestHandler(WSGIRequestHandler):
+class CommissaireRequestHandler(WSGIRequestHandler):
     """
     Commissaire version of the WSGIRequestHandler.
     """
@@ -63,7 +63,7 @@ class CommissaireHttpServer:
             self._bind_port,
             self.dispatcher.dispatch,
             server_class=ThreadedWSGIServer,
-            handler_class=CommisaireRequestHandler)
+            handler_class=CommissaireRequestHandler)
 
         # If we are given a PEM file then wrap the socket
         if tls_pem_file:

--- a/src/commissaire_http/bus/__init__.py
+++ b/src/commissaire_http/bus/__init__.py
@@ -1,0 +1,196 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Bus related classes and functions.
+"""
+
+import logging
+import uuid
+
+from kombu import Connection, Exchange, Producer, Queue
+
+
+class Bus:
+    """
+    Connection to a bus.
+    """
+
+    def __init__(self, exchange_name, connection_url, qkwargs):
+        """
+        Initializes a new Bus instance.
+
+        :param exchange_name: Name of the topic exchange.
+        :type exchange_name: str
+        :param connection_url: Kombu connection url.
+        :type connection_url: str
+        :param qkwargs: One or more dicts keyword arguments for queue creation
+        :type qkwargs: list
+        """
+        self.logger = logging.getLogger('Bus')
+        self.logger.debug('Initializing bus connection')
+        self.connection = None
+        self._channel = None
+        self._exchange = None
+        self.exchange_name = exchange_name
+        self.connection_url = connection_url
+        self.qkwargs = qkwargs
+
+    @property
+    def init_kwargs(self):
+        """
+        Returns the initializing kwargs for this instance.
+
+        :returns: the initializing kwargs for this instance.
+        :rtype: dict
+        """
+        return {
+            'exchange_name': self.exchange_name,
+            'connection_url': self.connection_url,
+            'qkwargs': self.qkwargs,
+        }
+
+    def connect(self):
+        """
+        'Connects' to the bus.
+
+        :returns: The same instance.
+        :rtype: commissaire_http.bus.Bus
+        """
+        self.connection = Connection(self.connection_url)
+        self._channel = self.connection.channel()
+        self._exchange = Exchange(
+            self.exchange_name, type='topic').bind(self._channel)
+        self._exchange.declare()
+
+        # Create queues
+        self._queues = []
+        for kwargs in self.qkwargs:
+            queue = Queue(**kwargs)
+            queue.exchange = self._exchange
+            queue = queue.bind(self._channel)
+            self._queues.append(queue)
+            self.logger.debug('Created queue {}'.format(queue.as_dict()))
+
+        # Create producer for publishing on topics
+        self.producer = Producer(self._channel, self._exchange)
+        self.logger.debug('Bus connection finished')
+        return self
+
+    # TODO: Everything under this line needs to move to a common module
+    #       shared between service and http
+
+    @classmethod
+    def create_id(cls):  # pragma: no cover
+        """
+        Creates a new unique identifier.
+
+        :returns: A unique identification string.
+        :rtype: str
+        """
+        return str(uuid.uuid4())
+
+    def respond(self, queue_name, id, payload, **kwargs):  # pragma: no cover
+        """
+        Sends a response to a simple queue. Responses are sent back to a
+        request and never should be the owner of the queue.
+
+        :param queue_name: The name of the queue to use.
+        :type queue_name: str
+        :param id: The unique request id
+        :type id: str
+        :param payload: The content of the message.
+        :type payload: dict
+        :param kwargs: Keyword arguments to pass to SimpleQueue
+        :type kwargs: dict
+        """
+        self.logger.debug('Sending response for message id "{}"'.format(id))
+        send_queue = self.connection.SimpleQueue(queue_name, **kwargs)
+        jsonrpc_msg = {
+            'jsonrpc': "2.0",
+            'id': id,
+            'result': payload,
+        }
+        self.logger.debug('jsonrpc msg: {}'.format(jsonrpc_msg))
+        send_queue.put(jsonrpc_msg)
+        self.logger.debug('Sent response for message id "{}"'.format(id))
+        send_queue.close()
+
+    def request(self, routing_key, method, params={}, **kwargs):  # pragma: no cover # NOQA
+        """
+        Sends a request to a simple queue. Requests create the initial response
+        queue and wait for a response.
+
+        :param routing_key: The routing key to publish on.
+        :type routing_key: str
+        :param method: The remote method to request.
+        :type method: str
+        :param params: Keyword parameters to pass to the remote method.
+        :type params: dict
+        :param kwargs: Keyword arguments to pass to SimpleQueue
+        :type kwargs: dict
+        :returns: Result
+        :rtype: tuple
+        """
+        id = self.create_id()
+        response_queue_name = 'response-{}'.format(id)
+        self.logger.debug('Creating response queue "{}"'.format(
+            response_queue_name))
+        queue_opts = {
+            'auto_delete': True,
+            'durable': False,
+        }
+        if kwargs.get('queue_opts'):
+            queue_opts.update(kwargs.pop('queue_opts'))
+
+        self.logger.debug('Response queue arguments: {}'.format(kwargs))
+
+        response_queue = self.connection.SimpleQueue(
+            response_queue_name,
+            queue_opts=queue_opts,
+            **kwargs)
+
+        jsonrpc_msg = {
+            'jsonrpc': "2.0",
+            'id': id,
+            'method': method,
+            'params': params,
+        }
+        self.logger.debug('jsonrpc message for id "{}": "{}"'.format(
+            id, jsonrpc_msg))
+
+        self.producer.publish(
+            jsonrpc_msg,
+            routing_key,
+            declare=[self._exchange],
+            reply_to=response_queue_name)
+
+        self.logger.debug(
+            'Sent message id "{}" to "{}". Waiting on response...'.format(
+                id, response_queue_name))
+
+        result = response_queue.get(block=True, timeout=10)
+        result.ack()
+
+        if 'error' in result.payload.keys():
+            self.logger.warn(
+                'Error returned from the message id "{}"'.format(
+                    id, result.payload))
+
+        self.logger.debug(
+            'Result retrieved from response queue "{}": payload="{}"'.format(
+                response_queue_name, result))
+        self.logger.debug('Closing queue {}'.format(response_queue_name))
+        response_queue.close()
+        return result.payload

--- a/src/commissaire_http/bus/__init__.py
+++ b/src/commissaire_http/bus/__init__.py
@@ -68,6 +68,10 @@ class Bus:
         :returns: The same instance.
         :rtype: commissaire_http.bus.Bus
         """
+        if self.connection is not None:
+            self.logger.warn('Bus already connected.')
+            return self
+
         self.connection = Connection(self.connection_url)
         self._channel = self.connection.channel()
         self._exchange = Exchange(

--- a/src/commissaire_http/handlers/__init__.py
+++ b/src/commissaire_http/handlers/__init__.py
@@ -46,7 +46,7 @@ def create_response(id, result=None, error=None):
     return jsonrpc_response
 
 
-def hello_world(message):  # pragma: no cover
+def hello_world(message, bus):  # pragma: no cover
     """
     Example function handler that simply says hello. If name is given
     in the query string it uses it.
@@ -57,12 +57,14 @@ def hello_world(message):  # pragma: no cover
     :rtype: dict
     """
     response_msg = {'Hello': 'there'}
+    # Example of using the bus ...
+    # print(bus.request('simple.add', 'add', params=[10, 20]))
     if message['params'].get('name'):
         response_msg['Hello'] = message['params']['name']
     return create_response(message['id'], response_msg)
 
 
-def create_world(message):  # pragma: no cover
+def create_world(message, bus):  # pragma: no cover
     """
     Example function handler that simply says hello. If name is given
     in the query string it uses it.
@@ -90,7 +92,7 @@ class ClassHandlerExample:  # pragma: no cover
     Example class based handlers.
     """
 
-    def hello(self, message):
+    def hello(self, message, bus):
         """
         Example method handler that simply says hello. If name is given
         in the query string it uses it.
@@ -100,4 +102,4 @@ class ClassHandlerExample:  # pragma: no cover
         :returns: A jsonrpc structure.
         :rtype: dict
         """
-        return hello_world(message)
+        return hello_world(message, bus)

--- a/test/test_bus.py
+++ b/test/test_bus.py
@@ -1,0 +1,72 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test for commissaire_http.bus
+"""
+
+from unittest import mock
+
+from . import TestCase
+from commissaire_http.bus import Bus
+
+EXCHANGE = 'exchange'
+CONNECTION_URL = 'redis://127.0.0.1:6379//'
+QUEUE_KWARGS = [{'name': 'simple', 'routing_key': 'simple.*'}]
+
+
+class TestBus(TestCase):
+    """
+    Test for the Bus class.
+    """
+
+    def setUp(self):
+        """
+        Creates a new instance to test with per test.
+        """
+        self.bus_instance = Bus(EXCHANGE, CONNECTION_URL, QUEUE_KWARGS)
+
+    def test_init_kwargs(self):
+        """
+        Verify the Bus.init_kwargs returns the arguments used to create the instance.
+        """
+        self.assertEquals(
+            {
+                'exchange_name': EXCHANGE,
+                'connection_url': CONNECTION_URL,
+                'qkwargs': QUEUE_KWARGS,
+            },
+            self.bus_instance.init_kwargs)
+
+    @mock.patch('commissaire_http.bus.Connection')
+    @mock.patch('commissaire_http.bus.Exchange')
+    @mock.patch('commissaire_http.bus.Producer')
+    def test_connect(self, _producer, _exchange, _connection):
+        """
+        Verify Bus.connect opens the connection to the bus.
+        """
+        self.bus_instance.connect()
+        # Connection should be called with the proper url
+        _connection.assert_called_once_with(self.bus_instance.connection_url)
+        _connection().channel.assert_called_once_with()
+        # Exchange should be called ...
+        _exchange.assert_called_once_with(
+            self.bus_instance.exchange_name, type='topic')
+        # .. and bound
+        # One queue should be Created
+        self.assertEqual(1, len(self.bus_instance._queues))
+        _exchange().bind.assert_called_once_with(self.bus_instance._channel)
+        # We should have a new producer
+        _producer.assert_called_once_with(
+            self.bus_instance._channel, self.bus_instance._exchange)

--- a/test/test_dispatcher.py
+++ b/test/test_dispatcher.py
@@ -37,7 +37,7 @@ class TestDispatcher(TestCase):
         """
         self.router_instance = Router()
         self.router_instance.connect(
-            '/path/',
+            '/hello/',
             controller='commissaire_http.handlers.hello_world',
             conditions={'method': 'GET'})
         self.router_instance.connect(
@@ -71,7 +71,7 @@ class TestDispatcher(TestCase):
         Verify the Dispatcher.dispatch works with valid paths.
         """
         environ = {
-            'PATH_INFO': '/path/',
+            'PATH_INFO': '/hello/',
             'REQUEST_METHOD': 'GET',
         }
         start_response = mock.MagicMock()
@@ -84,7 +84,7 @@ class TestDispatcher(TestCase):
         Verify the Dispatcher.dispatch works with valid paths and params.
         """
         environ = {
-            'PATH_INFO': '/path/',
+            'PATH_INFO': '/hello/',
             'REQUEST_METHOD': 'GET',
             'QUERY_STRING': 'name=bob'
         }


### PR DESCRIPTION
Handlers now are passed a bus input. If a bus is configured, the input will be an instance of ```commissaire_http.bus.Bus``` which provides a connection and methods to the bus to send and receive messages.

Docs are at https://github.com/projectatomic/commissaire/pull/2