### PR TITLE
Added network related endpoints.

### DIFF
--- a/src/commissaire_http/handlers/networks.py
+++ b/src/commissaire_http/handlers/networks.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Networks handlers.
+"""
+
+from commissaire_http.handlers import create_response
+
+
+def list_networks(message, bus):
+    """
+    Lists all networks.
+
+    :param message: jsonrpc message structure.
+    :type message: dict
+    :param bus: Bus instance.
+    :type bus: commissaire_http.bus.Bus
+    :returns: A jsonrpc structure.
+    :rtype: dict
+    """
+    networks_msg = bus.request('storage.list', params=['Networks'])
+    return create_response(
+        message['id'],
+        [network['name'] for network in networks_msg['result']])

--- a/src/commissaire_http/handlers/networks.py
+++ b/src/commissaire_http/handlers/networks.py
@@ -108,3 +108,30 @@ def create_network(message, bus):
         return create_response(message['id'], response['result'])
     except models.ValidationError as error:
         return return_error(message, error, JSONRPC_ERRORS['INVALID_REQUEST'])
+
+
+def delete_network(message, bus):
+    """
+    Deletes an exisiting network.
+
+    :param message: jsonrpc message structure.
+    :type message: dict
+    :param bus: Bus instance.
+    :type bus: commissaire_http.bus.Bus
+    :returns: A jsonrpc structure.
+    :rtype: dict
+    """
+    try:
+        LOGGER.debug('Attempting to delete network "{}"'.format(
+            message['params']['name']))
+        bus.request('storage.delete', params=[
+            'Network', {'name': message['params']['name']}])
+        return create_response(message['id'], [])
+    except _bus.RemoteProcedureCallError as error:
+        LOGGER.debug('Error deleting network: {}: {}'.format(
+            type(error), error))
+        return return_error(message, error, JSONRPC_ERRORS['NOT_FOUND'])
+    except Exception as error:
+        LOGGER.debug('Error deleting network: {}: {}'.format(
+            type(error), error))
+        return return_error(message, error, JSONRPC_ERRORS['INTERNAL_ERROR'])

--- a/src/commissaire_http/server/routing.py
+++ b/src/commissaire_http/server/routing.py
@@ -66,11 +66,16 @@ ROUTER.connect(
     },
     controller='commissaire_http.handlers.clusters.delete_cluster_member',
     conditions={'method': 'DELETE'})
-
+# Networks
+ROUTER.connect(
+    R'/api/v0/networks/',
+    controller='commissaire_http.handlers.networks.list_networks',
+    conditions={'method': 'GET'})
 
 #: Global HTTP dispatcher for the server
 DISPATCHER = Dispatcher(
     ROUTER,
     handler_packages=[
         'commissaire_http.handlers',
-        'commissaire_http.handlers.clusters'])
+        'commissaire_http.handlers.clusters',
+        'commissaire_http.handlers.networks'])

--- a/src/commissaire_http/server/routing.py
+++ b/src/commissaire_http/server/routing.py
@@ -71,6 +71,11 @@ ROUTER.connect(
     R'/api/v0/networks/',
     controller='commissaire_http.handlers.networks.list_networks',
     conditions={'method': 'GET'})
+ROUTER.connect(
+    R'/api/v0/network/{name}/',
+    requirements={'name': ROUTING_RX_PARAMS['name']},
+    controller='commissaire_http.handlers.networks.get_network',
+    conditions={'method': 'GET'})
 
 #: Global HTTP dispatcher for the server
 DISPATCHER = Dispatcher(

--- a/src/commissaire_http/server/routing.py
+++ b/src/commissaire_http/server/routing.py
@@ -81,6 +81,12 @@ ROUTER.connect(
     requirements={'name': ROUTING_RX_PARAMS['name']},
     controller='commissaire_http.handlers.networks.create_network',
     conditions={'method': 'PUT'})
+ROUTER.connect(
+    R'/api/v0/network/{name}/',
+    requirements={'name': ROUTING_RX_PARAMS['name']},
+    controller='commissaire_http.handlers.networks.delete_network',
+    conditions={'method': 'DELETE'})
+
 #: Global HTTP dispatcher for the server
 DISPATCHER = Dispatcher(
     ROUTER,

--- a/src/commissaire_http/server/routing.py
+++ b/src/commissaire_http/server/routing.py
@@ -76,7 +76,11 @@ ROUTER.connect(
     requirements={'name': ROUTING_RX_PARAMS['name']},
     controller='commissaire_http.handlers.networks.get_network',
     conditions={'method': 'GET'})
-
+ROUTER.connect(
+    R'/api/v0/network/{name}/',
+    requirements={'name': ROUTING_RX_PARAMS['name']},
+    controller='commissaire_http.handlers.networks.create_network',
+    conditions={'method': 'PUT'})
 #: Global HTTP dispatcher for the server
 DISPATCHER = Dispatcher(
     ROUTER,

--- a/test/test_handlers_networks.py
+++ b/test/test_handlers_networks.py
@@ -21,7 +21,7 @@ from unittest import mock
 from . import TestCase
 
 from commissaire.constants import JSONRPC_ERRORS
-from commissaire_http.handlers import create_response, clusters
+from commissaire_http.handlers import networks, create_response, clusters
 from commissaire.models import Network, ValidationError
 
 
@@ -46,3 +46,29 @@ class Test_networks(TestCase):
                 'id': '123',
             },
             clusters.list_clusters(bus.request.return_value, bus))
+
+    def test_get_network(self):
+        """
+        Verify get_network responds with the right information.
+        """
+        bus = mock.MagicMock()
+        bus.request.return_value = {
+                'jsonrpc': '2.0',
+                'result': Network.new(name='test').to_dict(),
+                'id': '123',
+            }
+        self.assertEquals(
+            {
+                'jsonrpc': '2.0',
+                'result': {
+                    'name': 'test',
+                    'type': 'flannel_etcd',
+                    'options': {},
+                },
+                'id': '123',
+            },
+            networks.get_network({
+                'jsonrpc': '2.0',
+                'id': '123',
+                'params': {'name': 'test'}
+                }, bus))

--- a/test/test_handlers_networks.py
+++ b/test/test_handlers_networks.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test for commissaire_http.handlers.networks module.
+"""
+
+from unittest import mock
+
+from . import TestCase
+
+from commissaire.constants import JSONRPC_ERRORS
+from commissaire_http.handlers import create_response, clusters
+from commissaire.models import Network, ValidationError
+
+
+class Test_networks(TestCase):
+    """
+    Test for the networks handlers.
+    """
+
+    def test_list_networks(self):
+        """
+        Verify list_networks responds with the right information.
+        """
+        bus = mock.MagicMock()
+        bus.request.return_value = {
+            'jsonrpc': '2.0',
+            'result': [Network.new(name='test').to_dict()],
+            'id': '123'}
+        self.assertEquals(
+            {
+                'jsonrpc': '2.0',
+                'result': ['test'],
+                'id': '123',
+            },
+            clusters.list_clusters(bus.request.return_value, bus))

--- a/test/test_handlers_networks.py
+++ b/test/test_handlers_networks.py
@@ -163,3 +163,67 @@ class Test_networks(TestCase):
                 'id': '123',
                 'params': {'name': 'test'}
                 }, bus))
+
+    def test_delete_network(self):
+        """
+        Verify delete_network deletes existing networks.
+        """
+        bus = mock.MagicMock()
+        bus.request.return_value = None
+        self.assertEquals(
+            {
+                'jsonrpc': '2.0',
+                'result': [],
+                'id': '123',
+            },
+            networks.delete_network({
+                'jsonrpc': '2.0',
+                'id': '123',
+                'params': {'name': 'test'}
+                }, bus))
+
+    def test_delete_network_not_found_on_missing_key(self):
+        """
+        Verify delete_network returns 404 on a missing network.
+        """
+        bus = mock.MagicMock()
+        bus.request.side_effect = _bus.RemoteProcedureCallError('test')
+        self.assertEquals(
+            {
+                'jsonrpc': '2.0',
+                'error': {
+                    'code': JSONRPC_ERRORS['NOT_FOUND'],
+                    'message': mock.ANY,
+                    'data': mock.ANY,
+                },
+                'id': '123',
+            },
+            networks.delete_network({
+                'jsonrpc': '2.0',
+                'id': '123',
+                'params': {'name': 'test'}
+                }, bus))
+
+    def test_delete_network_internal_error_on_exception(self):
+        """
+        Verify delete_network returns ISE on any other exception
+        """
+        # Iterate over a few errors
+        for error in (Exception, KeyError, TypeError):
+            bus = mock.MagicMock()
+            bus.request.side_effect = error('test')
+            self.assertEquals(
+                {
+                    'jsonrpc': '2.0',
+                    'error': {
+                        'code': JSONRPC_ERRORS['INTERNAL_ERROR'],
+                        'message': mock.ANY,
+                        'data': mock.ANY,
+                    },
+                    'id': '123',
+                },
+                networks.delete_network({
+                    'jsonrpc': '2.0',
+                    'id': '123',
+                    'params': {'name': 'test'}
+                    }, bus))


### PR DESCRIPTION
This PR implements the [network](http://commissaire.readthedocs.io/en/latest/endpoints.html#network) and [networks](http://commissaire.readthedocs.io/en/latest/endpoints.html#networks) endpoints.

- Added delete_network.
- Added create_network.
- Added get_network.
- Added list_networks.

Documentation updates will be handled in a [separate PR](https://github.com/projectatomic/commissaire/pull/20).