### PR TITLE
routing: Added optional_slashes.

### DIFF
--- a/src/commissaire_http/router/__init__.py
+++ b/src/commissaire_http/router/__init__.py
@@ -60,7 +60,7 @@ class Router(Mapper):
             if len(args) > 1:
                 url_path_idx = 1
             # If the url path ends with a forward slash then append the
-            # paramter regex to for matching and store it in _.
+            # parameter regex for matching and store it in _.
             if args[url_path_idx].endswith('/'):
                 args[url_path_idx] = args[url_path_idx][:-1] + '{_:[/]?}'
         # Call the parent connect to do the rest of the heavy lifting.

--- a/src/commissaire_http/router/__init__.py
+++ b/src/commissaire_http/router/__init__.py
@@ -30,6 +30,42 @@ class Router(Mapper):
     #: Class level logger
     logger = logging.getLogger('Router')
 
+    def __init__(self, optional_slash=False, *args, **kwargs):
+        """
+        :param optional_slash: If /'s are optional when matching directories.
+        :type optional_slash: bool
+        :param args: All non-keyword arguments.
+        :type args: tuple
+        :param kwargs: All other keyword arguments.
+        :type kwargs: dict
+        """
+        super().__init__(*args, **kwargs)
+        self._optional_slash = optional_slash
+
+    def connect(self, *args, **kwargs):
+        """
+        Overrides Mapper.connect adding in support for optional slashses.
+
+        :param args: All non-keyword arguments.
+        :type args: tuple
+        :param kwargs: All other keyword arguments.
+        :type kwargs: dict
+        """
+        # Cast to a list so we can modify the args
+        args = list(args)
+        # If we are asked to use an optional slash then find the url_path
+        # in the call. It is either the first or second element.
+        if self._optional_slash:
+            url_path_idx = 0
+            if len(args) > 1:
+                url_path_idx = 1
+            # If the url path ends with a forward slash then append the
+            # paramter regex to for matching and store it in _.
+            if args[url_path_idx].endswith('/'):
+                args[url_path_idx] = args[url_path_idx][:-1] + '{_:[/]?}'
+        # Call the parent connect to do the rest of the heavy lifting.
+        super().connect(*args, **kwargs)
+
     def match(self, *args, **kwargs):
         """
         Wraps routes.Mapper.match with topic specific results.

--- a/src/commissaire_http/server/routing.py
+++ b/src/commissaire_http/server/routing.py
@@ -22,7 +22,7 @@ from commissaire_http.dispatcher import Dispatcher
 from commissaire_http.router import Router
 
 #: Global HTTP router for the dispatcher
-ROUTER = Router()
+ROUTER = Router(optional_slash=True)
 ROUTER.connect(
     R'/api/v0/clusters/',
     controller='commissaire_http.handlers.clusters.list_clusters',


### PR DESCRIPTION
The routes library doesn't support optional slashes. This change
implements an optional slash pattern by overriding ```routes.Mapper'``s
``__init__`` and connect methods. When ``optional_slash`` is being used, ``connect``
will check to see if a url path ends with a ``/`` and, if it does, remove
said slash and replace it with the parameter regex ``{_:[/]?}``.

This should resolve #18.

**Note**: This should make the API as is mostly compatible with ``commctl``.