### PR TITLE
Idea: Handler registration

### DIFF
--- a/src/commissaire_http/dispatcher/__init__.py
+++ b/src/commissaire_http/dispatcher/__init__.py
@@ -193,7 +193,12 @@ class Dispatcher:
                 'Request transformed to "{}".'.format(jsonrpc_msg))
             # Get the resulting message back
             try:
-                handler = self._handler_map.get(route['controller'])
+                # If the handler registered is a callable, use it
+                if callable(route['controller']):
+                    handler = route['controller']
+                # Else load what we found earlier
+                else:
+                    handler = self._handler_map.get(route['controller'])
                 self.logger.debug('Using controller {}->{}'.format(
                     route, handler))
                 # Pass the message and, if needed, a new instance of the

--- a/src/commissaire_http/handlers/clusters.py
+++ b/src/commissaire_http/handlers/clusters.py
@@ -23,6 +23,64 @@ from commissaire import models
 from commissaire_http.handlers import LOGGER, create_response, return_error
 
 
+def _register(router):
+    """
+    Sets up routing for clusters.
+
+    :param router: Router instance to attach to.
+    :type router: commissaire_http.router.Router
+    :returns: The router.
+    :rtype: commissaire_http.router.Router
+    """
+    from commissaire_http.constants import ROUTING_RX_PARAMS
+
+    router.connect(
+        R'/api/v0/clusters/',
+        controller='commissaire_http.handlers.clusters.list_clusters',
+        conditions={'method': 'GET'})
+    router.connect(
+        R'/api/v0/cluster/{name}/',
+        requirements={'name': ROUTING_RX_PARAMS['name']},
+        controller='commissaire_http.handlers.clusters.get_cluster',
+        conditions={'method': 'GET'})
+    router.connect(
+        R'/api/v0/cluster/{name}/',
+        requirements={'name': ROUTING_RX_PARAMS['name']},
+        controller='commissaire_http.handlers.clusters.create_cluster',
+        conditions={'method': 'PUT'})
+    router.connect(
+        R'/api/v0/cluster/{name}/hosts/',
+        requirements={'name': ROUTING_RX_PARAMS['name']},
+        controller='commissaire_http.handlers.clusters.list_cluster_members',
+        conditions={'method': 'GET'})
+    router.connect(
+        R'/api/v0/cluster/{name}/hosts/{host}/',
+        requirements={
+            'name': ROUTING_RX_PARAMS['name'],
+            'host': ROUTING_RX_PARAMS['host'],
+        },
+        controller='commissaire_http.handlers.clusters.check_cluster_member',
+        conditions={'method': 'GET'})
+    router.connect(
+        R'/api/v0/cluster/{name}/hosts/{host}/',
+        requirements={
+            'name': ROUTING_RX_PARAMS['name'],
+            'host': ROUTING_RX_PARAMS['host'],
+        },
+        controller='commissaire_http.handlers.clusters.add_cluster_member',
+        conditions={'method': 'PUT'})
+    router.connect(
+        R'/api/v0/cluster/{name}/hosts/{host}/',
+        requirements={
+            'name': ROUTING_RX_PARAMS['name'],
+            'host': ROUTING_RX_PARAMS['host'],
+        },
+        controller='commissaire_http.handlers.clusters.delete_cluster_member',
+        conditions={'method': 'DELETE'})
+
+    return router
+
+
 def list_clusters(message, bus):
     """
     Lists all clusters.

--- a/src/commissaire_http/handlers/clusters.py
+++ b/src/commissaire_http/handlers/clusters.py
@@ -36,22 +36,22 @@ def _register(router):
 
     router.connect(
         R'/api/v0/clusters/',
-        controller='commissaire_http.handlers.clusters.list_clusters',
+        controller=list_clusters,
         conditions={'method': 'GET'})
     router.connect(
         R'/api/v0/cluster/{name}/',
         requirements={'name': ROUTING_RX_PARAMS['name']},
-        controller='commissaire_http.handlers.clusters.get_cluster',
+        controller=get_cluster,
         conditions={'method': 'GET'})
     router.connect(
         R'/api/v0/cluster/{name}/',
         requirements={'name': ROUTING_RX_PARAMS['name']},
-        controller='commissaire_http.handlers.clusters.create_cluster',
+        controller=create_cluster,
         conditions={'method': 'PUT'})
     router.connect(
         R'/api/v0/cluster/{name}/hosts/',
         requirements={'name': ROUTING_RX_PARAMS['name']},
-        controller='commissaire_http.handlers.clusters.list_cluster_members',
+        controller=list_cluster_members,
         conditions={'method': 'GET'})
     router.connect(
         R'/api/v0/cluster/{name}/hosts/{host}/',
@@ -59,7 +59,7 @@ def _register(router):
             'name': ROUTING_RX_PARAMS['name'],
             'host': ROUTING_RX_PARAMS['host'],
         },
-        controller='commissaire_http.handlers.clusters.check_cluster_member',
+        controller=check_cluster_member,
         conditions={'method': 'GET'})
     router.connect(
         R'/api/v0/cluster/{name}/hosts/{host}/',
@@ -67,7 +67,7 @@ def _register(router):
             'name': ROUTING_RX_PARAMS['name'],
             'host': ROUTING_RX_PARAMS['host'],
         },
-        controller='commissaire_http.handlers.clusters.add_cluster_member',
+        controller=add_cluster_member,
         conditions={'method': 'PUT'})
     router.connect(
         R'/api/v0/cluster/{name}/hosts/{host}/',
@@ -75,7 +75,7 @@ def _register(router):
             'name': ROUTING_RX_PARAMS['name'],
             'host': ROUTING_RX_PARAMS['host'],
         },
-        controller='commissaire_http.handlers.clusters.delete_cluster_member',
+        controller=delete_cluster_member,
         conditions={'method': 'DELETE'})
 
     return router

--- a/src/commissaire_http/handlers/hosts.py
+++ b/src/commissaire_http/handlers/hosts.py
@@ -23,6 +23,53 @@ from commissaire_http.constants import JSONRPC_ERRORS
 from commissaire_http.handlers import LOGGER, create_response, return_error
 
 
+def _register(router):
+    """
+    Sets up routing for hosts.
+
+    :param router: Router instance to attach to.
+    :type router: commissaire_http.router.Router
+    :returns: The router.
+    :rtype: commissaire_http.router.Router
+    """
+    from commissaire_http.constants import ROUTING_RX_PARAMS
+
+    router.connect(
+        R'/api/v0/hosts/',
+        controller='commissaire_http.handlers.hosts.list_hosts',
+        conditions={'method': 'GET'})
+    router.connect(
+        R'/api/v0/host/{address}/',
+        requirements={'address': ROUTING_RX_PARAMS['address']},
+        controller='commissaire_http.handlers.hosts.get_host',
+        conditions={'method': 'GET'})
+    router.connect(
+        R'/api/v0/host/{address}/',
+        requirements={'address': ROUTING_RX_PARAMS['address']},
+        controller='commissaire_http.handlers.hosts.create_host',
+        conditions={'method': 'PUT'})
+    router.connect(
+        R'/api/v0/host/',
+        controller='commissaire_http.handlers.hosts.create_host',
+        conditions={'method': 'PUT'})
+    router.connect(
+        R'/api/v0/host/{address}/creds',
+        requirements={'address': ROUTING_RX_PARAMS['address']},
+        controller='commissaire_http.handlers.hosts.get_hostcreds',
+        conditions={'method': 'GET'})
+    router.connect(
+        R'/api/v0/host/{address}/',
+        requirements={'address': ROUTING_RX_PARAMS['address']},
+        controller='commissaire_http.handlers.hosts.delete_host',
+        conditions={'method': 'DELETE'})
+    router.connect(
+        R'/api/v0/host/{address}/status/',
+        controller='commissaire_http.handlers.hosts.get_host_status',
+        conditions={'method': 'GET'})
+
+    return router
+
+
 def list_hosts(message, bus):
     """
     Lists all hosts.

--- a/src/commissaire_http/handlers/hosts.py
+++ b/src/commissaire_http/handlers/hosts.py
@@ -36,35 +36,35 @@ def _register(router):
 
     router.connect(
         R'/api/v0/hosts/',
-        controller='commissaire_http.handlers.hosts.list_hosts',
+        controller=list_hosts,
         conditions={'method': 'GET'})
     router.connect(
         R'/api/v0/host/{address}/',
         requirements={'address': ROUTING_RX_PARAMS['address']},
-        controller='commissaire_http.handlers.hosts.get_host',
+        controller=get_host,
         conditions={'method': 'GET'})
     router.connect(
         R'/api/v0/host/{address}/',
         requirements={'address': ROUTING_RX_PARAMS['address']},
-        controller='commissaire_http.handlers.hosts.create_host',
+        controller=create_host,
         conditions={'method': 'PUT'})
     router.connect(
         R'/api/v0/host/',
-        controller='commissaire_http.handlers.hosts.create_host',
+        controller=create_host,
         conditions={'method': 'PUT'})
     router.connect(
         R'/api/v0/host/{address}/creds',
         requirements={'address': ROUTING_RX_PARAMS['address']},
-        controller='commissaire_http.handlers.hosts.get_hostcreds',
+        controller=get_hostcreds,
         conditions={'method': 'GET'})
     router.connect(
         R'/api/v0/host/{address}/',
         requirements={'address': ROUTING_RX_PARAMS['address']},
-        controller='commissaire_http.handlers.hosts.delete_host',
+        controller=delete_host,
         conditions={'method': 'DELETE'})
     router.connect(
         R'/api/v0/host/{address}/status/',
-        controller='commissaire_http.handlers.hosts.get_host_status',
+        controller=get_host_status,
         conditions={'method': 'GET'})
 
     return router

--- a/src/commissaire_http/handlers/networks.py
+++ b/src/commissaire_http/handlers/networks.py
@@ -22,6 +22,41 @@ from commissaire_http.constants import JSONRPC_ERRORS
 from commissaire_http.handlers import LOGGER, create_response, return_error
 
 
+def _register(router):
+    """
+    Sets up routing for clusters.
+
+    :param router: Router instance to attach to.
+    :type router: commissaire_http.router.Router
+    :returns: The router.
+    :rtype: commissaire_http.router.Router
+    """
+    from commissaire_http.constants import ROUTING_RX_PARAMS
+
+    # Networks
+    router.connect(
+        R'/api/v0/networks/',
+        controller='commissaire_http.handlers.networks.list_networks',
+        conditions={'method': 'GET'})
+    router.connect(
+        R'/api/v0/network/{name}/',
+        requirements={'name': ROUTING_RX_PARAMS['name']},
+        controller='commissaire_http.handlers.networks.get_network',
+        conditions={'method': 'GET'})
+    router.connect(
+        R'/api/v0/network/{name}/',
+        requirements={'name': ROUTING_RX_PARAMS['name']},
+        controller='commissaire_http.handlers.networks.create_network',
+        conditions={'method': 'PUT'})
+    router.connect(
+        R'/api/v0/network/{name}/',
+        requirements={'name': ROUTING_RX_PARAMS['name']},
+        controller='commissaire_http.handlers.networks.delete_network',
+        conditions={'method': 'DELETE'})
+
+    return router
+
+
 def list_networks(message, bus):
     """
     Lists all networks.

--- a/src/commissaire_http/handlers/networks.py
+++ b/src/commissaire_http/handlers/networks.py
@@ -36,22 +36,22 @@ def _register(router):
     # Networks
     router.connect(
         R'/api/v0/networks/',
-        controller='commissaire_http.handlers.networks.list_networks',
+        controller=list_networks,
         conditions={'method': 'GET'})
     router.connect(
         R'/api/v0/network/{name}/',
         requirements={'name': ROUTING_RX_PARAMS['name']},
-        controller='commissaire_http.handlers.networks.get_network',
+        controller=get_network,
         conditions={'method': 'GET'})
     router.connect(
         R'/api/v0/network/{name}/',
         requirements={'name': ROUTING_RX_PARAMS['name']},
-        controller='commissaire_http.handlers.networks.create_network',
+        controller=create_network,
         conditions={'method': 'PUT'})
     router.connect(
         R'/api/v0/network/{name}/',
         requirements={'name': ROUTING_RX_PARAMS['name']},
-        controller='commissaire_http.handlers.networks.delete_network',
+        controller=delete_network,
         conditions={'method': 'DELETE'})
 
     return router

--- a/src/commissaire_http/server/routing.py
+++ b/src/commissaire_http/server/routing.py
@@ -16,109 +16,16 @@
 Routing items.
 """
 
-from commissaire_http.constants import ROUTING_RX_PARAMS
-
 from commissaire_http.dispatcher import Dispatcher
 from commissaire_http.router import Router
 
+from commissaire_http.handlers import clusters, hosts, networks
+
 #: Global HTTP router for the dispatcher
 ROUTER = Router(optional_slash=True)
-ROUTER.connect(
-    R'/api/v0/clusters/',
-    controller='commissaire_http.handlers.clusters.list_clusters',
-    conditions={'method': 'GET'})
-ROUTER.connect(
-    R'/api/v0/cluster/{name}/',
-    requirements={'name': ROUTING_RX_PARAMS['name']},
-    controller='commissaire_http.handlers.clusters.get_cluster',
-    conditions={'method': 'GET'})
-ROUTER.connect(
-    R'/api/v0/cluster/{name}/',
-    requirements={'name': ROUTING_RX_PARAMS['name']},
-    controller='commissaire_http.handlers.clusters.create_cluster',
-    conditions={'method': 'PUT'})
-ROUTER.connect(
-    R'/api/v0/cluster/{name}/hosts/',
-    requirements={'name': ROUTING_RX_PARAMS['name']},
-    controller='commissaire_http.handlers.clusters.list_cluster_members',
-    conditions={'method': 'GET'})
-ROUTER.connect(
-    R'/api/v0/cluster/{name}/hosts/{host}/',
-    requirements={
-        'name': ROUTING_RX_PARAMS['name'],
-        'host': ROUTING_RX_PARAMS['host'],
-    },
-    controller='commissaire_http.handlers.clusters.check_cluster_member',
-    conditions={'method': 'GET'})
-ROUTER.connect(
-    R'/api/v0/cluster/{name}/hosts/{host}/',
-    requirements={
-        'name': ROUTING_RX_PARAMS['name'],
-        'host': ROUTING_RX_PARAMS['host'],
-    },
-    controller='commissaire_http.handlers.clusters.add_cluster_member',
-    conditions={'method': 'PUT'})
-ROUTER.connect(
-    R'/api/v0/cluster/{name}/hosts/{host}/',
-    requirements={
-        'name': ROUTING_RX_PARAMS['name'],
-        'host': ROUTING_RX_PARAMS['host'],
-    },
-    controller='commissaire_http.handlers.clusters.delete_cluster_member',
-    conditions={'method': 'DELETE'})
-# Networks
-ROUTER.connect(
-    R'/api/v0/networks/',
-    controller='commissaire_http.handlers.networks.list_networks',
-    conditions={'method': 'GET'})
-ROUTER.connect(
-    R'/api/v0/network/{name}/',
-    requirements={'name': ROUTING_RX_PARAMS['name']},
-    controller='commissaire_http.handlers.networks.get_network',
-    conditions={'method': 'GET'})
-ROUTER.connect(
-    R'/api/v0/network/{name}/',
-    requirements={'name': ROUTING_RX_PARAMS['name']},
-    controller='commissaire_http.handlers.networks.create_network',
-    conditions={'method': 'PUT'})
-ROUTER.connect(
-    R'/api/v0/network/{name}/',
-    requirements={'name': ROUTING_RX_PARAMS['name']},
-    controller='commissaire_http.handlers.networks.delete_network',
-    conditions={'method': 'DELETE'})
-# Hosts
-ROUTER.connect(
-    R'/api/v0/hosts/',
-    controller='commissaire_http.handlers.hosts.list_hosts',
-    conditions={'method': 'GET'})
-ROUTER.connect(
-    R'/api/v0/host/{address}/',
-    requirements={'address': ROUTING_RX_PARAMS['address']},
-    controller='commissaire_http.handlers.hosts.get_host',
-    conditions={'method': 'GET'})
-ROUTER.connect(
-    R'/api/v0/host/{address}/',
-    requirements={'address': ROUTING_RX_PARAMS['address']},
-    controller='commissaire_http.handlers.hosts.create_host',
-    conditions={'method': 'PUT'})
-ROUTER.connect(
-    R'/api/v0/host/',
-    controller='commissaire_http.handlers.hosts.create_host',
-    conditions={'method': 'PUT'})
-ROUTER.connect(
-    R'/api/v0/host/{address}/creds',
-    requirements={'address': ROUTING_RX_PARAMS['address']},
-    controller='commissaire_http.handlers.hosts.get_hostcreds',
-    conditions={'method': 'GET'})
-ROUTER.connect(
-    R'/api/v0/host/{address}/',
-    requirements={'address': ROUTING_RX_PARAMS['address']},
-    controller='commissaire_http.handlers.hosts.delete_host',
-    conditions={'method': 'DELETE'})
-ROUTER.connect(
-    R'/api/v0/host/{address}/status/',
-    controller='commissaire_http.handlers.hosts.get_host_status',
-    conditions={'method': 'GET'})
+hosts._register(ROUTER)
+clusters._register(ROUTER)
+networks._register(ROUTER)
 
 #: Global HTTP dispatcher for the server
 DISPATCHER = Dispatcher(


### PR DESCRIPTION
The ``routing`` module was already starting to seem like it was getting too long. Before it becomes out of hand I decided to try one possible solution which is to have the handlers provide a way to register. This set of commits implements the following idea:

- The handler modules have a ``_register`` function which takes, updates, and returns the ``router``
- The ``routing`` module calls all handlers ``_register`` functions
- The ``dispatcher`` has added support to go directly to a callable