### PR TITLE
Reformat Dockerfile and remove redundant clean call

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,18 +8,19 @@ ENV PYTHONPATH  /commissaire-http/src/
 # NOTE: gcc, libffi-devel and openssl-devel are required to build some of the
 #       dependencies when using pip. redhat-rpm-config has at least one file
 #       referenced by one of the build dependencies.
-RUN dnf -y update && dnf -y install --setopt=tsflags=nodocs redhat-rpm-config python3-pip python3-virtualenv git gcc libffi-devel openssl-devel ; dnf clean all && \
-git clone https://github.com/projectatomic/commissaire-http.git && \
-py3-virtualenv /environment && \
-. /environment/bin/activate && \
-cd commissaire-http && \
-pip install -U pip && \
-pip install -r requirements.txt && \
-pip install git+https://github.com/projectatomic/commissaire.git && \
-pip freeze > /installed-python-deps.txt  && \
-pip install -e . && \
-dnf remove -y gcc git redhat-rpm-config libffi-devel && \
-dnf clean all
+RUN dnf update -y && \
+    dnf install -y --setopt=tsflags=nodocs redhat-rpm-config python3-pip python3-virtualenv git gcc libffi-devel openssl-devel && \
+    git clone https://github.com/projectatomic/commissaire-http.git && \
+    py3-virtualenv /environment && \
+    . /environment/bin/activate && \
+    cd commissaire-http && \
+    pip install -U pip && \
+    pip install -r requirements.txt && \
+    pip install git+https://github.com/projectatomic/commissaire.git && \
+    pip freeze > /installed-python-deps.txt  && \
+    pip install -e . && \
+    dnf remove -y gcc git redhat-rpm-config libffi-devel && \
+    dnf clean all
 
 EXPOSE 8000
 WORKDIR /commissaire-http


### PR DESCRIPTION
A small change, but remove the redundant dnf clean call. Also, this was performed without &&, which means that the former installation could fail and would continue. It would however fail later in the run due to missing commands, like `pip`. Also reformatted by indenting the lines, which makes it easier to read and realize it is a multiline statement.