### PR TITLE
AuthN Plugin Response Handling

### DIFF
--- a/test/test_authenticator.py
+++ b/test/test_authenticator.py
@@ -46,3 +46,18 @@ class Test_Authenticator(TestCase):
         """
         self.assertFalse(self.authenticator.authenticate(
             create_environ(), mock.MagicMock()))
+
+    def test_authenticator_WSGI_interface_default_failure(self):
+        """
+        Verify Authenticator's WSGI interface properly fails authn by default.
+        """
+        self.assertEquals([bytes('Forbidden', 'utf8')], self.authenticator(
+            create_environ(), mock.MagicMock()))
+
+    def test_authenticator_WSGI_interface_allows_successes(self):
+        """
+        Verify Authenticator's WSGI interface properly allows authn success.
+        """
+        self.authenticator.authenticate = mock.MagicMock(return_value=True)
+        self.assertEquals(DUMMY_WSGI_BODY, self.authenticator(
+            create_environ(), mock.MagicMock()))

--- a/test/test_authenticator.py
+++ b/test/test_authenticator.py
@@ -61,3 +61,13 @@ class Test_Authenticator(TestCase):
         self.authenticator.authenticate = mock.MagicMock(return_value=True)
         self.assertEquals(DUMMY_WSGI_BODY, self.authenticator(
             create_environ(), mock.MagicMock()))
+
+    def test_authenticator_WSGI_interface_with_controlling_plugin(self):
+        """
+        Verify Authenticator's WSGI interface properly works when a plugin controls responses.
+        """
+        body = [bytes('test', 'utf8')]
+        start_response = mock.MagicMock()
+        self.authenticator.authenticate = mock.MagicMock(return_value=body)
+        self.assertEquals(body, self.authenticator(
+            create_environ(), start_response))

--- a/test/test_authenticator.py
+++ b/test/test_authenticator.py
@@ -22,6 +22,12 @@ from . import TestCase, create_environ
 
 from commissaire_http import authentication
 
+# The response from dummy_wsgi_app
+DUMMY_WSGI_BODY = [bytes('hi', 'utf8')]
+
+def dummy_wsgi_app(environ, start_response):
+    return DUMMY_WSGI_BODY
+
 
 class Test_Authenticator(TestCase):
     """
@@ -32,7 +38,7 @@ class Test_Authenticator(TestCase):
         """
         Sets up a fresh instance of the class before each run.
         """
-        self.authenticator = authentication.Authenticator(None)
+        self.authenticator = authentication.Authenticator(dummy_wsgi_app)
 
     def test_authenticator_authenticate(self):
         """

--- a/test/test_authenticator_httpbasicauth.py
+++ b/test/test_authenticator_httpbasicauth.py
@@ -16,11 +16,6 @@
 Test cases for the commissaire_http.authentication package.
 """
 
-
-# NOTE: commenting out etcd related loading until we have the storage
-#       service
-#import etcd
-
 from . import TestCase, create_environ, get_fixture_file_path
 
 from unittest import mock
@@ -33,7 +28,13 @@ class Test_SharedBasicAuth(TestCase):
     """
     Tests for the shared BasicAuth function.
     """
-    
+
+    def setUp(self):
+        """
+        Sets up a fresh instance of the class before each run.
+        """
+        self.http_basic_auth = httpbasicauth.HTTPBasicAuth(None, users={})
+
     def test_decode_basic_auth(self):
         """
         Verify decoding returns a filled tuple given the proper header no matter the case of basic.
@@ -112,6 +113,7 @@ class TestHTTPBasicAuthByFile(TestCase):
             self.http_basic_auth.authenticate(environ, mock.MagicMock()))
 
 
+# TODO: StorageService based?
 '''
 class TestHTTPBasicAuthByEtcd(TestCase):
     """


### PR DESCRIPTION
Authentication plugins can now directly handle the HTTP response body, headers, and code directly if wanted. To handle the responses within the plugin ``start_response`` must be called and a list (the response body) must be returned. If the plugin wants to allow the plugin system to handle the rejection the plugin should continue to return ``True`` on success and ``False`` on failed authentication.
    
Example:
```python
def authenticate(self, environ, start_response):
    start_response('200 OK', [('content-type', 'text/plain')])
       return [bytes('example', 'utf8')]
```

May help for #31