### PR TITLE
auth: AuthN now occurs via the AuthenticationManager.

### DIFF
--- a/conf/commissaire.conf
+++ b/conf/commissaire.conf
@@ -2,12 +2,12 @@
     "listen-interface": "127.0.0.1",
     "listen-port": 8000,
     "bus-uri": "redis://127.0.0.1:6379/",
-    "authentication-plugin": {
+    "authentication-plugins": [{
         "name": "commissaire_http.authentication.httpbasicauth",
         "users": {
             "a": {
                 "hash": "$2a$12$GlBCEIwz85QZUCkWYj11he6HaRHufzIvwQjlKeu7Rwmqi/mWOpRXK"
             }
         }
-    }
+    }]
 }

--- a/src/commissaire_http/util/cli.py
+++ b/src/commissaire_http/util/cli.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Utilities for CLI.
+"""
+
+
+def parse_to_struct(inp):
+    """
+    Parses a command line structure into a dictionary creation structure.
+
+    :param inp: The input string from argparse.
+    :type inp: str
+    :returns: The parsed structure in a pre dictionary format.
+    :rtype: list
+    """
+    name, args = inp.split(':')
+    new = {name: {}}
+    for item in args.split(','):
+        try:
+            k, v = item.split('=')
+            new[name][k] = v
+        except ValueError:
+            # Ignore values with out equals
+            pass
+    return new

--- a/test/test_authentication_manager.py
+++ b/test/test_authentication_manager.py
@@ -1,0 +1,100 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test cases for the commissaire_http.authentication.AuthenticationManager class.
+"""
+
+from unittest import mock
+
+from . import TestCase, create_environ
+
+from commissaire_http import authentication
+
+# The response from dummy_wsgi_app
+DUMMY_WSGI_BODY = [bytes('hi', 'utf8')]
+
+# Dummy wsgi app for testing
+def dummy_wsgi_app(environ, start_response):
+    start_response('200 OK', [])
+    return DUMMY_WSGI_BODY
+
+
+class Test_AuthenticationManager(TestCase):
+    """
+    Tests for the AuthenticationManager class.
+    """
+
+    def setUp(self):
+        """
+        Sets up a fresh instance of the class before each run.
+        """
+        self.authenticator = authentication.Authenticator(dummy_wsgi_app)
+        self.authentication_manager = authentication.AuthenticationManager(
+            dummy_wsgi_app,
+            authenticators=[self.authenticator])
+
+    def test_authentication_manager_simple_deny(self):
+        """
+        Verify AuthenticationManager handles the simple forbidden case.
+        """
+        start_response = mock.MagicMock()
+        result = self.authentication_manager(create_environ(), start_response)
+        self.assertEquals([bytes('Forbidden', 'utf8')], result)
+        start_response.assert_called_once_with('403 Forbidden', mock.ANY)
+
+    def test_authentication_manager_simple_allow(self):
+        """
+        Verify AuthenticationManager handles the simple allow case.
+        """
+        start_response = mock.MagicMock()
+        self.authenticator.authenticate = mock.MagicMock(return_value=True)
+        result = self.authentication_manager(create_environ(), start_response)
+        self.assertEquals(DUMMY_WSGI_BODY, result)
+        start_response.assert_called_once_with('200 OK', mock.ANY)
+
+    def test_authenticator_manager_complex_failure(self):
+        """
+        Verify AuthenticationManager handles the complex forbidden case.
+        """
+        body = [bytes('test', 'utf8')]
+        start_response = mock.MagicMock()
+        sr_args = ('403 Forbidden', [])
+
+        # Override the authenticators authenticate with a complex failure
+        def authenticate(_, sr):
+            sr(*sr_args)
+            return body
+
+        self.authenticator.authenticate = authenticate
+        self.assertEquals(body, self.authenticator(
+            create_environ(), start_response))
+        start_response.assert_called_once_with(*sr_args)
+
+    def test_authenticator_manager_complex_success(self):
+        """
+        Verify AuthenticationManager handles the complex success case.
+        """
+        start_response = mock.MagicMock()
+        sr_args = ('200 OK', [])
+
+        # Override the authenticators authenticate with a complex success
+        def authenticate(_, sr):
+            sr(*sr_args)
+            return []  # Ignored
+
+        self.authenticator.authenticate = authenticate
+        self.assertEquals(DUMMY_WSGI_BODY, self.authenticator(
+            create_environ(), start_response))
+        start_response.assert_called_once_with(*sr_args)

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -20,8 +20,8 @@ from unittest import mock
 
 from . import TestCase
 
-from commissaire_http.authentication import Authenticator
-from commissaire_http.server.cli import main, inject_authentication
+from commissaire_http.authentication import AuthenticationManager
+from commissaire_http.server import cli
 from commissaire_http.dispatcher import Dispatcher
 
 
@@ -35,40 +35,43 @@ class TestServerCli(TestCase):
         """
         Verify the server is started when main is executed.
         """
-        main()
+        cli.main()
         _server().serve_forever.assert_called_once_with()
 
 
 class TestInjectAuthentication(TestCase):
     """
-    Tests for the inject_authentication function.
+    Tests for the cli.inject_authentication function.
     """
+
+    # def tearDown(self):
+    #     cli.DISPATCHER.dispatch.authenticators = []
 
     def test_inject_authentication_with_no_kwargs(self):
         """
-        Verify inject_authentication works when no kwargs are given.
+        Verify cli.inject_authentication works when no kwargs are given.
         """
-        result = inject_authentication(
-            'commissaire_http.authentication.httpbasicauth', {})
+        result = cli.inject_authentication(
+            {'commissaire_http.authentication.httpbasicauth': {}})
         self.assertIsInstance(result, Dispatcher)
-        self.assertIsInstance(result.dispatch, Authenticator)
+        self.assertIsInstance(result.dispatch, AuthenticationManager)
 
     def test_inject_authentication_with_kwargs(self):
         """
-        Verify inject_authentication works when kwargs are given.
+        Verify cli.inject_authentication works when kwargs are given.
         """
-        result = inject_authentication(
-            'commissaire_http.authentication.httpbasicauth',
-            'filepath=conf/users.json')
+        result = cli.inject_authentication({
+            'commissaire_http.authentication.httpbasicauth': {
+                'filepath': 'conf/users.json',
+        }})
         self.assertIsInstance(result, Dispatcher)
-        self.assertIsInstance(result.dispatch, Authenticator)
+        self.assertIsInstance(result.dispatch, AuthenticationManager)
 
     def test_inject_authentication_with_a_missing_authenticator(self):
         """
-        Verify inject_authentication raises when an authenticator doesn't exist.
+        Verify cli.inject_authentication raises when an authenticator doesn't exist.
         """
         self.assertRaises(
             ImportError,
-            inject_authentication,
-            'commissaire_http.doesnotexist',
-            {})
+            cli.inject_authentication,
+            {'commissaire_http.doesnotexist': {}})

--- a/test/test_util_cli.py
+++ b/test/test_util_cli.py
@@ -1,0 +1,51 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test cases for the commissaire_http.util.cli module.
+"""
+
+from . import TestCase
+
+from commissaire_http.util import cli
+
+
+class Test_parse_to_struct(TestCase):
+    """
+    Tests for the parse_to_struct function
+    """
+
+    def test_parse_to_struct_with_class_only(self):
+        """
+        Verify parse_to_struct creates a proper struct with only a class name.
+        """
+        self.assertEquals(
+            {'someclass': {}},
+            cli.parse_to_struct('someclass:'))
+
+    def test_parse_to_struct_with_class_and_args(self):
+        """
+        Verify parse_to_struct creates a proper struct with a class and args.
+        """
+        self.assertEquals(
+            {'someclass': {'k': 'v', 'a': 'b'}},
+            cli.parse_to_struct('someclass:k=v,a=b'))
+
+    def test_parse_to_struct_ignore_unparsable_args(self):
+        """
+        Verify parse_to_struct ignores unparsable items in args.
+        """
+        self.assertEquals(
+            {'someclass': {'k': 'v'}},
+            cli.parse_to_struct('someclass:k=v,IDONOTBELONG'))

--- a/test/test_util_wsgi.py
+++ b/test/test_util_wsgi.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Test cases for the commissaire_http.util.wsgi module.
+"""
+
+from . import TestCase
+
+from commissaire_http.util import wsgi
+
+
+class Test_AuthenticationManager(TestCase):
+    """
+    Tests for the AuthenticationManager class.
+    """
+
+    def setUp(self):
+        """
+        Sets up a fresh instance of the class before each run.
+        """
+        self.fake_start_response = wsgi.FakeStartResponse()
+
+    def test_fake_start_response_call_count(self):
+        """
+        Verify FakeStartResponse holds the correct call count.
+        """
+        for x in range(1, 11):
+            self.fake_start_response('200 OK', [])
+            self.assertEquals(x, self.fake_start_response.call_count)
+
+    def test_fake_start_response_stores_code_and_headers(self):
+        """
+        Verify FakeStartResponse holds the latest code and headers.
+        """
+        test_args = [
+            ('200 OK', ()),
+            ('403 Forbidden', (('content-type', 'text/html')))]
+
+        for args in test_args:
+            self.fake_start_response(*args)
+            # Each iteration should match the latest
+            self.assertEquals(
+                args[0],
+                self.fake_start_response.code)
+            self.assertEquals(
+                args[1],
+                self.fake_start_response.headers)
+
+        # The end result should ONLY be the latest
+        self.assertEquals(
+            test_args[-1][0],
+            self.fake_start_response.code)
+        self.assertEquals(
+            test_args[-1][1],
+            self.fake_start_response.headers)


### PR DESCRIPTION
Previously a single `Authenticator` plugin was defined solely responsible
for authn. This change adds an `AuthenticationManager` which can stack
multiple `Authenticator` plugins. The `AuthenticationManager` will attempt
each plugin until either one plugin succeeds or all fail. In the case
all fail the last plugins response is used.

Other updates:
- The configuration format for plugins is now a list of objects instead of an object itself.
- If no authentication plugins are provided the default 'deny all' implementation is used.
- The format for `--authentication-plugin` is now `MODULE:key=value,...`

Resolves #33.
