### PR TITLE
auth: Stacked complex plugins no longer have to be last.

### DIFF
--- a/src/commissaire_http/authentication/__init__.py
+++ b/src/commissaire_http/authentication/__init__.py
@@ -152,7 +152,8 @@ class AuthenticationManager:
             # The plugin handled it's own start_response and
             # return data. Pull from the fake_start_response and return
             # the result from authenticate.
-            elif result is not False and fake_start_response.call_count > 0:
+            elif isinstance(
+                    result, list) and fake_start_response.call_count > 0:
                 self.logger.debug('{} succeeded authentication.'.format(
                     authenticator.__class__.__name__))
                 self.logger.debug('Response: {}'.format(fake_start_response))

--- a/src/commissaire_http/authentication/__init__.py
+++ b/src/commissaire_http/authentication/__init__.py
@@ -109,6 +109,9 @@ class AuthenticationManager:
     Handles stacking Authenticators.
     """
 
+    #: Logger for AuthenticationManager
+    logger = logging.getLogger('AuthenticationManager')
+
     def __init__(self, app, authenticators=[]):
         """
         Initializes a new AuthenticationManager instance.
@@ -143,20 +146,27 @@ class AuthenticationManager:
             result = authenticator.authenticate(environ, fake_start_response)
             # True means it was successful
             if result is True:
+                self.logger.debug('{} succeeded authentication.'.format(
+                    authenticator.__class__.__name__))
                 return self._app(environ, start_response)
+            # The plugin handled it's own start_response and
+            # return data. Pull from the fake_start_response and return
+            # the result from authenticate.
+            elif result is not False and fake_start_response.call_count > 0:
+                self.logger.debug('{} succeeded authentication.'.format(
+                    authenticator.__class__.__name__))
+                self.logger.debug('Response: {}'.format(fake_start_response))
+                start_response(
+                    fake_start_response.code, fake_start_response.headers)
+                return result
+            else:
+                self.logger.debug('{} failed authentication: {}'.format(
+                    authenticator.__class__.__name__, result))
 
-        # If the last result was False, do a generic Forbidden.
-        if result is False:
-            start_response(
-                '403 Forbidden', [('content-type', 'text/html')])
-            return [bytes('Forbidden', 'utf8')]
-        # Otherwise the plugin handled it's own start_response and
-        # return data. Pull from the fake_start_response and return
-        # the result from authenticate.
-        else:
-            start_response(
-                fake_start_response.body, fake_start_response.headers)
-            return result
+        # Else fall through to a generic Forbidden.
+        start_response(
+            '403 Forbidden', [('content-type', 'text/html')])
+        return [bytes('Forbidden', 'utf8')]
 
 
 def decode_basic_auth(logger, http_auth):

--- a/src/commissaire_http/server/cli.py
+++ b/src/commissaire_http/server/cli.py
@@ -28,7 +28,7 @@ from commissaire_http import CommissaireHttpServer, parse_args
 
 # TODO: Make this configurable
 for name in (
-        'authentication',
+        'authentication', 'AuthenticationManager',
         'Dispatcher', 'Router', 'Bus', 'CommissaireHttpServer', 'Handlers'):
     logger = logging.getLogger(name)
     logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
This change adds:

- Logger for ``AuthenticationManager``
- Updated tests for ``AuthenticationManager``
- Allows complex plugins to exist anywhere in the ``AuthenticationManager`` authenticator list.

Builds upon #38