### PR TITLE
Implement logging from commissaire common lib

### DIFF
--- a/conf/commissaire.conf
+++ b/conf/commissaire.conf
@@ -9,5 +9,29 @@
                 "hash": "$2a$12$GlBCEIwz85QZUCkWYj11he6HaRHufzIvwQjlKeu7Rwmqi/mWOpRXK"
             }
         }
-    }]
+    }],
+    "logging-format": "%(name)s(%(levelname)s): %(message)s",
+    "logging-levels": {
+            "authentication": {
+                "level": "DEBUG"
+            },
+            "AuthenticationManager": {
+                "level": "DEBUG"
+            },
+            "Dispatcher": {
+                "level": "DEBUG"
+            },
+            "Router": {
+                "level": "DEBUG"
+            },
+            "Bus": {
+                "level": "DEBUG"
+            },
+            "CommissaireHttpServer": {
+                "level": "DEBUG"
+            },
+            "Handlers": {
+                "level": "DEBUG"
+            }
+      }
 }

--- a/src/commissaire_http/__init__.py
+++ b/src/commissaire_http/__init__.py
@@ -46,6 +46,9 @@ def parse_args(parser):
     # Do not use required=True because it would preclude such
     # arguments from being specified in a configuration file.
     parser.add_argument(
+        '--debug', action='store_true',
+        help='Turn on debug logging to stdout')
+    parser.add_argument(
         '--config-file', '-c', type=str,
         help='Full path to a JSON configuration file '
              '(command-line arguments override)')

--- a/src/commissaire_http/server/cli.py
+++ b/src/commissaire_http/server/cli.py
@@ -18,25 +18,13 @@ Commissaire HTTP based application server.
 """
 import argparse
 import importlib
-import logging
+
+from commissaire.util.logging import setup_logging
 
 from commissaire_http.authentication import (
     AuthenticationManager, Authenticator)
 from commissaire_http.server.routing import DISPATCHER  # noqa
 from commissaire_http import CommissaireHttpServer, parse_args
-
-
-# TODO: Make this configurable
-for name in (
-        'authentication', 'AuthenticationManager',
-        'Dispatcher', 'Router', 'Bus', 'CommissaireHttpServer', 'Handlers'):
-    logger = logging.getLogger(name)
-    logger.setLevel(logging.DEBUG)
-    handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter(
-        '%(name)s(%(levelname)s): %(message)s'))
-    logger.handlers.append(handler)
-# --
 
 
 def inject_authentication(plugins):
@@ -83,6 +71,15 @@ def main():
     epilog = 'Example: commissaire -c conf/myconfig.json'
     parser = argparse.ArgumentParser(epilog=epilog)
     args = parse_args(parser)
+
+    components = ('authentication',
+                  'AuthenticationManager',
+                  'Dispatcher',
+                  'Router',
+                  'Bus',
+                  'CommissaireHttpServer',
+                  'Handlers')
+    setup_logging(args, components)
 
     try:
         # Inject the authentication plugin


### PR DESCRIPTION
This commit introduces logging using the commissaire logging setup
function. The config file params are optional, and default to the
'info' logging level, but are set to 'debug' to provide an example
of logging configuration.

This commit requires https://github.com/projectatomic/commissaire/pull/54

Resolves #22