### PR TITLE
Fix Bus Passing

### DIFF
--- a/src/commissaire_http/__init__.py
+++ b/src/commissaire_http/__init__.py
@@ -203,8 +203,15 @@ class CommissaireHttpServer:
         :type qkwargs: list
         """
         self.logger.debug('Setting up bus connection.')
-        self.bus = Bus(exchange_name, connection_url, qkwargs)
+        bus_init_kwargs = {
+            'exchange_name': exchange_name,
+            'connection_url': connection_url,
+            'qkwargs': qkwargs}
+        self.bus = Bus(**bus_init_kwargs)
+        self.logger.debug('Bus instance created with: {}'.format(
+            bus_init_kwargs))
         self.bus.connect()
+        # Inject the bus
         self.dispatcher._bus = self.bus
         self.logger.info('Bus connection ready.')
 

--- a/test/test_dispatcher.py
+++ b/test/test_dispatcher.py
@@ -22,6 +22,7 @@ from io import BytesIO
 
 from . import TestCase, mock
 
+from commissaire_http.bus import Bus
 from commissaire_http.dispatcher import Dispatcher
 from commissaire_http.router import Router
 
@@ -46,7 +47,8 @@ class TestDispatcher(TestCase):
             conditions={'method': 'PUT'})
         self.dispatcher_instance = Dispatcher(
             self.router_instance,
-            handler_packages=['commissaire_http.handlers']
+            handler_packages=['commissaire_http.handlers'],
+            bus=mock.MagicMock('Bus')
         )
 
     def test_dispatcher_initialization(self):


### PR DESCRIPTION
This change removes old ``Bus`` passing code and makes it easier to pass a ``Bus`` instance to the ``Dispatcher``.