### PR TITLE
bug: cluster_get now uses the storage client correctly.

### DIFF
--- a/src/commissaire_http/handlers/clusters/__init__.py
+++ b/src/commissaire_http/handlers/clusters/__init__.py
@@ -129,7 +129,7 @@ def get_cluster(message, bus):
 
     cluster.status = C.CLUSTER_STATUS_OK
     for host_address in cluster.hostset:
-        host = bus.storage.get(host_address)
+        host = bus.storage.get(models.Host.new(address=host_address))
         total += 1
         if host.status == 'active':
             available += 1


### PR DESCRIPTION
The usage of the storage client was not updated in the ``cluster_get``
handler. It was still taking a raw address rather than a model instance.
This change forces the use of a model instance to ``bus.storage.get``.