### PR TITLE
auth: Add self-auth option

### DIFF
--- a/conf/commissaire.conf
+++ b/conf/commissaire.conf
@@ -10,5 +10,6 @@
             }
         }
     }],
+    "self-auths": ["/api/v0/secrets"],
     "debug": false
 }

--- a/src/commissaire_http/__init__.py
+++ b/src/commissaire_http/__init__.py
@@ -73,6 +73,9 @@ def parse_args(parser):
         metavar='MODULE_NAME:key=value,..', type=parse_to_struct,
         help=('Authentication Plugin module and configuration.'))
     parser.add_argument(
+        '--self-auth', action='append', dest='self_auths',
+        help='URI paths which provide their own authentication.')
+    parser.add_argument(
         '--bus-exchange', type=str, default='commissaire',
         help='Message bus exchange name.')
     parser.add_argument(

--- a/src/commissaire_http/server/cli.py
+++ b/src/commissaire_http/server/cli.py
@@ -26,19 +26,19 @@ from commissaire_http.server.routing import DISPATCHER  # noqa
 from commissaire_http import CommissaireHttpServer, parse_args
 
 
-def inject_authentication(plugins):
+def inject_authentication(plugins, self_auths=None):
     """
     Injects authentication into the dispatcher's dispatch method.
 
     :param plugin: Name of the Authenticator plugin.
     :type plugin: str
-    :param kwargs: Arguments for the Authenticator
-    :type kwargs: dict or list
+    :param self_auths: Paths that provide their own authentication.
+    :type self_auths: None or [str]
     :returns: A wrapped Dispatcher instance
     :rtype: commissaire.dispatcher.Dispatcher
     """
     global DISPATCHER
-    authn_manager = AuthenticationManager(DISPATCHER.dispatch)
+    authn_manager = AuthenticationManager(DISPATCHER.dispatch, self_auths)
     for module_name in plugins:
         authentication_class = import_plugin(
             module_name, 'commissaire_http.authentication', Authenticator)
@@ -73,7 +73,9 @@ def main():
 
     try:
         # Inject the authentication plugin
-        DISPATCHER = inject_authentication(args.authentication_plugins)
+        DISPATCHER = inject_authentication(
+            args.authentication_plugins,
+            args.self_auths)
 
         # Connect to the bus
         DISPATCHER.setup_bus(

--- a/test/test_authentication_manager.py
+++ b/test/test_authentication_manager.py
@@ -43,7 +43,8 @@ class Test_AuthenticationManager(TestCase):
         self.authenticator = authentication.Authenticator(dummy_wsgi_app)
         self.authentication_manager = authentication.AuthenticationManager(
             dummy_wsgi_app,
-            authenticators=[self.authenticator])
+            authenticators=[self.authenticator],
+            self_auths=['/passthrough'])
 
     def test_authentication_manager_simple_deny(self):
         """
@@ -159,4 +160,14 @@ class Test_AuthenticationManager(TestCase):
         ]
         result = self.authentication_manager(create_environ(), start_response)
         self.assertEquals(expected_result, result)
+        start_response.assert_called_once_with('200 OK', mock.ANY)
+
+    def test_authentication_self_auths(self):
+        """
+        Verify AuthenticationManager passes self_auths without checking.
+        """
+        start_response = mock.MagicMock()
+        result = self.authentication_manager(
+            create_environ(path='/passthrough'), start_response)
+        self.assertEquals(DUMMY_WSGI_BODY, result)
         start_response.assert_called_once_with('200 OK', mock.ANY)


### PR DESCRIPTION
AuthenticationManager can now be handed a self-auth list. Each item in
this list denotes a local HTTP/S path that provides it's own
authN/authZ. The AuthenticationManager will pass the request directly
to the endpoint without using Commissaire's authentication stack.

The option can be set via the command line:
```
    $ commissaire-http [...] \
      --self-auth /some/path \
      --self-auth /anotherpath
```
or by adding a "self_auth" to the configuration file:
```
   [...]
   "self_auth": ["/some/path", "/anotherpath"],
   [...]
```
Ref: https://github.com/projectatomic/commissaire/issues/101