### PR TITLE
auth: Use keyword argument for self-auths

### DIFF
--- a/src/commissaire_http/server/cli.py
+++ b/src/commissaire_http/server/cli.py
@@ -38,7 +38,8 @@ def inject_authentication(plugins, self_auths=None):
     :rtype: commissaire.dispatcher.Dispatcher
     """
     global DISPATCHER
-    authn_manager = AuthenticationManager(DISPATCHER.dispatch, self_auths)
+    authn_manager = AuthenticationManager(
+        DISPATCHER.dispatch, self_auths=self_auths)
     for module_name in plugins:
         authentication_class = import_plugin(
             module_name, 'commissaire_http.authentication', Authenticator)


### PR DESCRIPTION
The self auths actually would fail as they would not make it to the ``AuthenticationManager``. This forces the use of a keyword argument to ensure they are set no matter if args change in the manager.